### PR TITLE
Update python_version for 3.13

### DIFF
--- a/ipstack.json
+++ b/ipstack.json
@@ -14,7 +14,7 @@
     "utctime_updated": "2025-04-11T18:26:40.853517Z",
     "package_name": "phantom_ipstack",
     "main_module": "ipstack_connector.py",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "min_phantom_version": "5.1.0",
     "fips_compliant": true,
     "latest_tested_versions": [

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)